### PR TITLE
Fix isort checker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ line_length = 100
 wrap_length = 100
 multi_line_output = 3
 include_trailing_comma = true
+known_third_party = ["agentql"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
After we renamed `fish-tank` repo into `agentql`, isort is getting confused now when we import `agentql`. It thinks its a first party lib, so it wants to sort imports differently. See https://github.com/tinyfish-io/agentql/pull/72
In this context `agentql` is a third party lib, so explicitly forcing it to be such